### PR TITLE
Don't stop the audio session when stopping keep alive

### DIFF
--- a/src/ios/APPBackgroundMode.m
+++ b/src/ios/APPBackgroundMode.m
@@ -139,9 +139,6 @@ NSString* const kAPPBackgroundEventDeactivate = @"deactivate";
     }
 
     [audioPlayer pause];
-
-    AVAudioSession* session = [AVAudioSession sharedInstance];
-    [session setActive:NO error:NULL];
 }
 
 /**


### PR DESCRIPTION
Since `cordova-plugin-background-mode` doesn't control the audio session in our app, it should never set it to be inactive.